### PR TITLE
Remove GPU 151MHz - Bug: 240479599

### DIFF
--- a/arch/arm64/boot/dts/google/gs101-gpu.dtsi
+++ b/arch/arm64/boot/dts/google/gs101-gpu.dtsi
@@ -85,9 +85,8 @@
 		>;
 
 		/* DVFS Level locks */
-		gpu_dvfs_max_freq = <800000>;
-		gpu_dvfs_min_freq = <250000>;
-		gpu_dvfs_min_freq_compute = <450000>; /* When compute work detected */
+		gpu_dvfs_max_freq = <900000>;
+		gpu_dvfs_min_freq = <0>;
 
 		/* QOS */
 		gpu_dvfs_qos_bts_scenario = "g3d_performance";

--- a/arch/arm64/boot/dts/google/gs101-gpu.dtsi
+++ b/arch/arm64/boot/dts/google/gs101-gpu.dtsi
@@ -64,7 +64,7 @@
 		>;
 
 		/* DVFS v2 operating points */
-		gpu_dvfs_table_size_v2 = <12 10>; /*<row col>*/
+		gpu_dvfs_table_size_v2 = <11 10>; /*<row col>*/
 		gpu_dvfs_table_v2 = <
 			/*
 			 *gpu0    gpu1   down     up    hys      int      mif   little  middle   big
@@ -82,7 +82,6 @@
 			434000  302000     60     90      3        0        0        0       0     0
 			434000  251000     50     80      2        0        0        0       0     0
 			302000  202000     45     67      1        0        0        0       0     0
-			302000  151000      0     70      1        0        0        0       0     0
 		>;
 
 		/* DVFS Level locks */

--- a/arch/arm64/boot/dts/google/gs101-gpu.dtsi
+++ b/arch/arm64/boot/dts/google/gs101-gpu.dtsi
@@ -87,7 +87,7 @@
 
 		/* DVFS Level locks */
 		gpu_dvfs_max_freq = <800000>;
-		gpu_dvfs_min_freq = <150000>;
+		gpu_dvfs_min_freq = <250000>;
 		gpu_dvfs_min_freq_compute = <450000>; /* When compute work detected */
 
 		/* QOS */


### PR DESCRIPTION
Google have Removed GPU 151MHz operating point into pixel 7 sources I beleave pixel 6 have potential issues also. ( actually I have no specific issue in my devices due to kirisakura kernel )

*gChips discovered potential issues with this frequency, and has
recommended its removal.
Bug: 240479599
Change-Id: Ib408a15ac71e3b7cef159ed997de29c138fb6ed2
Signed-off-by: Jeremy Kemp <jeremykemp@google.com>