### PR TITLE
google/sched/cpufreq_gov : backport: cpuidle: teo: Introduce util-awa…

### DIFF
--- a/drivers/soc/google/vh/kernel/sched/cpufreq_gov.c
+++ b/drivers/soc/google/vh/kernel/sched/cpufreq_gov.c
@@ -569,6 +569,12 @@ unsigned long schedutil_cpu_util_pixel_mod(int cpu, unsigned long util_cfs,
 	return min(max, util);
 }
 
+unsigned long sched_cpu_util(int cpu, unsigned long max)
+{
+	return schedutil_cpu_util(cpu, cpu_util_cfs(cpu_rq(cpu)), max,
+				  ENERGY_UTIL, NULL);
+}
+
 static unsigned long sugov_get_util(struct sugov_cpu *sg_cpu)
 {
 	struct rq *rq = cpu_rq(sg_cpu->cpu);


### PR DESCRIPTION
…reness

[Aarqw12 : BACKPORT in cpufreq_gov for pixel 6/7 ]